### PR TITLE
Fix CD "Release" step and bump version

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -153,7 +153,7 @@ jobs:
           body: |
             Published to PyPI: https://pypi.org/project/gits-statuses/${{ steps.get_version.outputs.version }}/
           files: |
-            dist/*
+            python-pypi/dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       

--- a/python-pypi/pyproject.toml
+++ b/python-pypi/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gits-statuses"
-version = "0.1.0"
+version = "0.1.1"
 description = "A CLI tool to scan directories for Git repositories and display their status information."
 requires-python = ">=3.8"
 authors = [


### PR DESCRIPTION
# Summary
- Update incorrect file path
- Bump version for release

# Details
- GitHub action CD "release" step failing as the release is looking for the build file within the  `dist/` directory of the root

#### Error:
[Link to failing step](https://github.com/nicolgit/gits-statuses/actions/runs/16374446496/job/46270760243)
```bash
🤔 Pattern 'dist/*' does not match any files.
👩‍🏭 Creating new GitHub release for tag v0.1.0...
⚠️ GitHub release failed with status: 403
undefined
retrying... (2 retries remaining)
👩‍🏭 Creating new GitHub release for tag v0.1.0...
⚠️ GitHub release failed with status: 403
undefined
retrying... (1 retries remaining)
👩‍🏭 Creating new GitHub release for tag v0.1.0...
⚠️ GitHub release failed with status: 403
undefined
retrying... (0 retries remaining)
❌ Too many retries. Aborting...
Error: Too many retries.
```

#### Fix:
- Point the release to look in `python-pypi/dist/` which is where the build artifacts actually exist