### PR TITLE
Add explicit build step to release

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -144,6 +144,10 @@ jobs:
           VERSION=$(grep -m1 'version = ' pyproject.toml | cut -d'"' -f2)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+      - name: Build package
+        run: |
+          uv build
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:

--- a/python-pypi/pyproject.toml
+++ b/python-pypi/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gits-statuses"
-version = "0.1.2"
+version = "0.1.3"
 description = "A CLI tool to scan directories for Git repositories and display their status information."
 requires-python = ">=3.8"
 authors = [

--- a/python-pypi/pyproject.toml
+++ b/python-pypi/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gits-statuses"
-version = "0.1.1"
+version = "0.1.2"
 description = "A CLI tool to scan directories for Git repositories and display their status information."
 requires-python = ">=3.8"
 authors = [


### PR DESCRIPTION
# Summary
Fix GitHub release workflow to properly include distribution files in "Release" step by adding an explicit build step. (also realizing that this CD step was probably silently failing in my other projects that are not in a monorepo structure LOL).

Thank you for your patience Nicola!!! My bad for the bug aha.

# Details
- Add `uv build` step in the release job which explicitly builds distribution files 
- This resolves the issue where the release action couldn't find `dist/*` files because they weren't being built in the release job environment