### PR TITLE
Add permissions for write access to contents in CI/CD workflow

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -12,6 +12,9 @@ on:
       - 'python-pypi/src/**'
       - 'python-pypi/pyproject.toml'
 
+permissions:
+  contents: write
+
 jobs:
   ci-version-check:
     if: github.event_name == 'pull_request'

--- a/python-pypi/pyproject.toml
+++ b/python-pypi/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gits-statuses"
-version = "0.1.3"
+version = "0.1.31"
 description = "A CLI tool to scan directories for Git repositories and display their status information."
 requires-python = ">=3.8"
 authors = [


### PR DESCRIPTION
# Summary
The last fixes #8 and #9 are now working HOWEVER, looks like there is an authentication / permissions error with the GitHub token. 

# Details
Based on this [thread](https://github.com/softprops/action-gh-release/issues/236) on the same error message that's showing up in the most recent error logs:
```bash
⚠️ GitHub release failed with status: 403
```
... it looks like we can try and add a config in the workflow YML to enable write permissions. 

Unfortunately, this part of the CI/CD pipeline is hard to test locally since I'm not the repo owner.. but we definitely can just give this a shot!

Can you try and test this locally before merging @nicolgit ? No rush as well. I'm just at the library right now with my girlfriend as she studies for her boards exam haha
