### PR TITLE
formatter: add last commit hash to detailed view

### DIFF
--- a/python-pypi/pyproject.toml
+++ b/python-pypi/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gits-statuses"
-version = "0.1.40"
+version = "0.1.50"
 description = "A CLI tool to scan directories for Git repositories and display their status information."
 requires-python = ">=3.8"
 authors = [

--- a/python-pypi/src/git_tools/formatter.py
+++ b/python-pypi/src/git_tools/formatter.py
@@ -65,6 +65,8 @@ class TableFormatter:
         untracked_width = max(max_untracked_width, len("Untracked"))
 
         if show_url:
+            max_rev_width = max(len(repo.rev) for repo in display_repositories)
+            rev_width = max(max_rev_width, len("Commit"))
             max_url_width = max(len(repo.remote_url) for repo in display_repositories)
             url_width = max(max_url_width, len("Remote URL"))
             max_commits_width = max(
@@ -75,7 +77,7 @@ class TableFormatter:
             status_width = max(max_status_width, len("Status"))
 
             # Create header with URL
-            header = f"{'Repository':<{name_width}} | {'Branch':<{branch_width}} | {'Ahead':<{ahead_width}} | {'Behind':<{behind_width}} | {'Changed':<{changed_width}} | {'Untracked':<{untracked_width}} | {'Total Commits':<{commits_width}} | {'Status':<{status_width}} | {'Remote URL':<{url_width}}"
+            header = f"{'Repository':<{name_width}} | {'Branch':<{branch_width}} | {'Commit':<{rev_width}} | {'Ahead':<{ahead_width}} | {'Behind':<{behind_width}} | {'Changed':<{changed_width}} | {'Untracked':<{untracked_width}} | {'Total Commits':<{commits_width}} | {'Status':<{status_width}} | {'Remote URL':<{url_width}}"
             separator = "-" * len(header)
 
             # Create rows with URL
@@ -87,7 +89,7 @@ class TableFormatter:
                 untracked_str = (
                     str(repo.untracked_count) if repo.untracked_count > 0 else ""
                 )
-                row = f"{repo.name:<{name_width}} | {repo.branch:<{branch_width}} | {ahead_str:<{ahead_width}} | {behind_str:<{behind_width}} | {changed_str:<{changed_width}} | {untracked_str:<{untracked_width}} | {repo.total_commits:<{commits_width}} | {repo.status:<{status_width}} | {repo.remote_url:<{url_width}}"
+                row = f"{repo.name:<{name_width}} | {repo.branch:<{branch_width}} | {repo.rev:<{rev_width}} | {ahead_str:<{ahead_width}} | {behind_str:<{behind_width}} | {changed_str:<{changed_width}} | {untracked_str:<{untracked_width}} | {repo.total_commits:<{commits_width}} | {repo.status:<{status_width}} | {repo.remote_url:<{url_width}}"
                 rows.append(row)
         else:
             # Create header without URL

--- a/python-pypi/src/git_tools/repository.py
+++ b/python-pypi/src/git_tools/repository.py
@@ -30,6 +30,7 @@ class GitRepository:
 
         if self.is_valid:
             self.branch = self._get_current_branch()
+            self.rev = self._get_current_revision()
             self.remote_url = self._get_remote_url()
             self.ahead_count = self._get_ahead_count()
             self.behind_count = self._get_behind_count()
@@ -39,6 +40,7 @@ class GitRepository:
             self.status = self._get_status_summary()
         else:
             self.branch = "Unknown"
+            self.rev = "Unknown"
             self.remote_url = "No remote"
             self.ahead_count = 0
             self.behind_count = 0
@@ -68,6 +70,30 @@ class GitRepository:
             FileNotFoundError,
         ):
             return False
+
+    def _get_current_revision(self) -> str:
+        """
+        Get the current commit hash.
+        Returns:
+            str: The current commit hash.
+        """
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=self.path,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0 and (rev := result.stdout.strip()):
+                return rev
+            return "Unknown"
+        except (
+            subprocess.TimeoutExpired,
+            subprocess.SubprocessError,
+            FileNotFoundError,
+        ):
+            return "Unknown"
 
     def _get_current_branch(self) -> str:
         """

--- a/python-pypi/tests/test_formatter.py
+++ b/python-pypi/tests/test_formatter.py
@@ -68,6 +68,7 @@ class TestTableFormatterRepositories:
         repo = Mock()
         repo.name = "test-repo"
         repo.branch = "feature"
+        repo.rev = "918e0c222f7ca5ea91794c0679cc414e03430bad"
         repo.ahead_count = 1
         repo.behind_count = 0
         repo.changed_count = 2
@@ -83,6 +84,7 @@ class TestTableFormatterRepositories:
         assert len(lines) >= 3  # header, separator, at least one row
         assert "Repository" in lines[0]
         assert "Branch" in lines[0]
+        assert "Commit" in lines[0]
         assert "Total Commits" in lines[0]
         assert "Status" in lines[0]
         assert "Remote URL" in lines[0]
@@ -90,6 +92,7 @@ class TestTableFormatterRepositories:
         # Check that all repo data is present
         assert "test-repo" in result
         assert "feature" in result
+        assert "918e0c222f7ca5ea91794c0679cc414e03430bad" in result
         assert "42" in result  # total commits
         assert "↑1 ~2 ?1" in result  # status
         assert "https://github.com/user/test-repo.git" in result
@@ -100,6 +103,7 @@ class TestTableFormatterRepositories:
         clean_repo = Mock()
         clean_repo.name = "clean-repo"
         clean_repo.branch = "main"
+        clean_repo.rev = "918e0c222f7ca5ea91794c0679cc414e03430bad"
         clean_repo.ahead_count = 0
         clean_repo.behind_count = 0
         clean_repo.changed_count = 0
@@ -112,6 +116,7 @@ class TestTableFormatterRepositories:
         dirty_repo = Mock()
         dirty_repo.name = "dirty-repo"
         dirty_repo.branch = "develop"
+        dirty_repo.rev = "918e0c222f7ca5ea91794c0679cc414e03430bad"
         dirty_repo.ahead_count = 3
         dirty_repo.behind_count = 2
         dirty_repo.changed_count = 5
@@ -138,6 +143,7 @@ class TestTableFormatterRepositories:
         short_repo = Mock()
         short_repo.name = "a"
         short_repo.branch = "main"
+        short_repo.rev = "918e0c222f7ca5ea91794c0679cc414e03430bad"
         short_repo.ahead_count = 0
         short_repo.behind_count = 0
         short_repo.changed_count = 0
@@ -149,6 +155,7 @@ class TestTableFormatterRepositories:
         long_repo = Mock()
         long_repo.name = "very-long-repository-name"
         long_repo.branch = "feature-branch"
+        long_repo.rev = "918e0c222f7ca5ea91794c0679cc414e03430bad"
         long_repo.ahead_count = 10
         long_repo.behind_count = 5
         long_repo.changed_count = 15
@@ -169,6 +176,7 @@ class TestTableFormatterRepositories:
 
         # Check that longer name is accommodated
         assert "very-long-repository-name" in result
+        assert "918e0c222f7ca5ea91794c0679cc414e03430bad" in result
         assert "feature-branch" in result
 
     def test_format_repositories_empty_values_handling(self):
@@ -177,6 +185,7 @@ class TestTableFormatterRepositories:
         repo = Mock()
         repo.name = "test-repo"
         repo.branch = "main"
+        repo.rev = "918e0c222f7ca5ea91794c0679cc414e03430bad"
         repo.ahead_count = 0  # Should display as empty
         repo.behind_count = 2  # Should display as "2"
         repo.changed_count = 0  # Should display as empty
@@ -195,6 +204,7 @@ class TestTableFormatterRepositories:
         # This is a bit tricky to test directly, but we can check the structure
         assert "test-repo" in data_line
         assert "main" in data_line
+        assert "918e0c222f7ca5ea91794c0679cc414e03430bad" in data_line
         assert "2" in data_line  # behind count
         assert "1" in data_line  # untracked count
         assert "20" in data_line  # total commits
@@ -272,6 +282,7 @@ class TestTableFormatterIntegration:
         repo = Mock()
         repo.name = "test-repo"
         repo.branch = "main"
+        repo.rev = "918e0c222f7ca5ea91794c0679cc414e03430bad"
         repo.ahead_count = 1
         repo.behind_count = 0
         repo.changed_count = 2
@@ -294,14 +305,17 @@ class TestTableFormatterIntegration:
         )
 
         # Standard view should not have URL or total commits
+        assert "Commit" not in standard_result
         assert "Remote URL" not in standard_result
         assert "Total Commits" not in standard_result
         assert "Status" not in standard_result
 
         # Detailed view should have URL and total commits
+        assert "Commit" in detailed_result
         assert "Remote URL" in detailed_result
         assert "Total Commits" in detailed_result
         assert "Status" in detailed_result
+        assert "918e0c222f7ca5ea91794c0679cc414e03430bad" in detailed_result
         assert "https://github.com/user/test-repo.git" in detailed_result
         assert "50" in detailed_result
         assert "↑1 ~2 ?1" in detailed_result

--- a/python-pypi/tests/test_repository.py
+++ b/python-pypi/tests/test_repository.py
@@ -172,6 +172,41 @@ class TestGitRepositoryBranch:
         assert result == "Unknown"
 
 
+class TestGitRepositoryRevision:
+    """Tests for revision information retrieval."""
+
+    @patch("subprocess.run")
+    def test_get_current_revision_success(self, mock_run):
+        """Test _get_current_branch with successful result."""
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = "918e0c222f7ca5ea91794c0679cc414e03430bad\n"
+
+        repo = GitRepository("/path/to/repo")
+        result = repo._get_current_revision()
+
+        assert result == "918e0c222f7ca5ea91794c0679cc414e03430bad"
+
+    @patch("subprocess.run")
+    def test_get_current_revision_error(self, mock_run):
+        """Test _get_current_revision with git error."""
+        mock_run.return_value.returncode = 1
+
+        repo = GitRepository("/path/to/repo")
+        result = repo._get_current_revision()
+
+        assert result == "Unknown"
+
+    @patch("subprocess.run")
+    def test_get_current_revision_timeout(self, mock_run):
+        """Test _get_current_revision with timeout."""
+        mock_run.side_effect = subprocess.TimeoutExpired(["git"], 5)
+
+        repo = GitRepository("/path/to/repo")
+        result = repo._get_current_revision()
+
+        assert result == "Unknown"
+
+
 class TestGitRepositoryRemote:
     """Tests for remote URL retrieval."""
 

--- a/python-pypi/uv.lock
+++ b/python-pypi/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.8"
 resolution-markers = [
     "python_full_version >= '3.9'",
@@ -241,7 +241,7 @@ wheels = [
 
 [[package]]
 name = "gits-statuses"
-version = "0.0.4"
+version = "0.1.50"
 source = { editable = "." }
 dependencies = [
     { name = "pip", version = "25.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
Hi, @nicolgit!

I came across your tool while needing to retrieve the status of many repos in the same folder and found it useful, but it lacked info about the current hash. Since it's been useful for me, I decided to create a PR to add this info to the detailed view. Feel free to integrate this if you'd like and let me know if you find anything that can be improved.

Thanks!